### PR TITLE
Use all options provided  by user to instantiate S3Client.

### DIFF
--- a/src/Adaptor/S3AdapterFactory.php
+++ b/src/Adaptor/S3AdapterFactory.php
@@ -11,7 +11,7 @@ class S3AdapterFactory implements FactoryInterface
 {
     public function __invoke(array $options)
     {
-        $options = array_merge([
+        $options = array_replace([
             'key' => null,
             'secret' => null,
             'region' => 'us-east-1',
@@ -22,6 +22,13 @@ class S3AdapterFactory implements FactoryInterface
 
         $bucket = $options['bucket'];
         $prefix = $options['prefix'];
+
+        if (!array_key_exists('credentials', $options)) {
+            $credentials = [];
+            $credentials['key']  = $options['key'];
+            $credentials['secret'] = $options['secret'];
+            $options['credentials'] = $credentials;
+        }
 
         $client = new S3Client($options);
 

--- a/src/Adaptor/S3AdapterFactory.php
+++ b/src/Adaptor/S3AdapterFactory.php
@@ -11,21 +11,19 @@ class S3AdapterFactory implements FactoryInterface
 {
     public function __invoke(array $options)
     {
-        $key = $options['key'] ?? null;
-        $secret = $options['secret'] ?? null;
-        $region = $options['region'] ?? 'us-east-1';
-        $version = $options['version'] ?? 'latest';
-        $bucket = $options['bucket'] ?? null;
-        $prefix = $options['prefix'] ?? null;
+        $options = array_merge([
+            'key' => null,
+            'secret' => null,
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'bucket' => null,
+            'prefix' => null,
+        ], $options);
 
-        $client = new S3Client([
-            'version'     => $version,
-            'region'      => $region,
-            'credentials' => [
-                'key'    => $key,
-                'secret' => $secret
-            ]
-        ]);
+        $bucket = $options['bucket'];
+        $prefix = $options['prefix'];
+
+        $client = new S3Client($options);
 
         return new AwsS3Adapter($client, $bucket, $prefix);
     }


### PR DESCRIPTION
Amazon AWS S3Client uses more options than previously supported by S3AdapterFactory class. With this fix all options provided by user will be used in S3Client constructor.

Further details: [https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html)